### PR TITLE
tweaked image position math to fix non-full rotation issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+test.html

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ OR the hard way:
 
    `<script src="/path/to/knobs.js"></script>`
 
-3. Edit knobs.js line 64 to reflect the path to the knob_Images folder
+3. Edit knobs.js line 65 to reflect the path to the knob_Images folder
 
    `./path/to/knob_Images/`  
    

--- a/knobs.js
+++ b/knobs.js
@@ -61,7 +61,8 @@ class Knob {
     let imgDiv = document.createElement("div");
     // let src = "./jsaudioknobs/knob_Images/" + this.imgFile;
     let src =
-      "https://colinbd.github.io/JSAudioKnobs/jsaudioknobs/knobs/" +
+      //"./knob_Images/" +
+      "https://raw.githubusercontent.com/ColinBD/JSAudioKnobs/master/docs/knobs/" +
       this.imgFile;
     imgDiv.innerHTML = `<img draggable='false' style='pointer-events: none; transform: translateY(0px);' src=${src}>`;
     let lblDiv = document.createElement("div");
@@ -146,7 +147,7 @@ class Knob {
   setImage() {
     //change the image position to match
     let sum =
-      (Math.floor(((this.currentValue - this.lowVal) * this.scaler) / 2) - 1) *
+      (Math.floor((this.currentValue - this.lowVal) * this.scaler) / 2) *
       this.size;
 
     let newY = `translateY(-${sum}px)`;
@@ -234,8 +235,8 @@ function createGlobalEventHandlers() {
           ((knobInUse.currentKnob.currentValue - knobInUse.currentKnob.lowVal) *
             knobInUse.currentKnob.scaler) /
             2
-        ) -
-          1) *
+        ) +
+          0) *
         knobInUse.currentKnob.size;
       let newY = `translateY(-${sum}px)`;
       //access to the image goes: container div > image wrapper div > image tag


### PR DESCRIPTION
This PR should resolve issue 1. The math for image positioning is tweaked by removing the '-1' part within two places in the code.