### PR TITLE
removed final '-1' so if a knob was initially set to full, the corres…

### DIFF
--- a/knobs.js
+++ b/knobs.js
@@ -147,7 +147,7 @@ class Knob {
   setImage() {
     //change the image position to match
     let sum =
-      (Math.floor(((this.currentValue - this.lowVal) * this.scaler) / 2) - 1) *
+      (Math.floor(((this.currentValue - this.lowVal) * this.scaler) / 2) + 0) *
       this.size;
 
     let newY = `translateY(-${sum}px)`;


### PR DESCRIPTION
…ponding full image would display